### PR TITLE
feat: add support for separate attach command

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,22 +91,26 @@ require("devcontainer").setup {
   -- This can be useful to mount local configuration
   -- And any other mounts when attaching to containers with this plugin
   attach_mounts = {
+    -- Can be set to true to always mount items defined below
+    -- And not only when directly attaching
+    -- This can be useful if executing attach command separately
+    always = false,
     neovim_config = {
       -- enables mounting local config to /root/.config/nvim in container
-      enabled = true,
+      enabled = false,
       -- makes mount readonly in container
       options = { "readonly" }
     },
     neovim_data = {
       -- enables mounting local data to /root/.local/share/nvim in container
-      enabled = true,
+      enabled = false,
       -- no options by default
       options = {}
     },
     -- Only useful if using neovim 0.8.0+
     neovim_state = {
       -- enables mounting local state to /root/.local/state/nvim in container
-      enabled = true,
+      enabled = false,
       -- no options by default
       options = {}
     },
@@ -136,6 +140,8 @@ If not disabled by using `generate_commands = false` in setup, this plugin provi
 - `DevcontainerComposeDown` - run docker-compose down based on devcontainer.json
 - `DevcontainerComposeRm` - run docker-compose rm based on devcontainer.json
 - `DevcontainerStartAuto` - start whatever is defined in devcontainer.json
+- `DevcontainerStartAutoAndAttach` - start and attach to whatever is defined in devcontainer.json
+- `DevcontainerAttachAuto` - attach to whatever is defined in devcontainer.json
 - `DevcontainerStopAuto` - stop whatever was started based on devcontainer.json
 - `DevcontainerStopAll` - stop everything started with this plugin (in current session)
 - `DevcontainerRemoveAll` - remove everything started with this plugin (in current session)

--- a/lua/devcontainer/config.lua
+++ b/lua/devcontainer/config.lua
@@ -149,26 +149,30 @@ M.devcontainer_json_template = default_devcontainer_json_template
 ---@field options List[string]|nil additional bind options, useful to define { "readonly" }
 
 ---@class AttachMountsOpts
+---@field always boolean|nil if true these mounts are used on every run, to be available when attaching later
 ---@field neovim_config MountOpts|nil if true attaches neovim local config to /root/.config/nvim in container
 ---@field neovim_data MountOpts|nil if true attaches neovim data to /root/.local/share/nvim in container
 ---@field neovim_state MountOpts|nil if true attaches neovim state to /root/.local/state/nvim in container
 ---@field custom_mounts List[string] list of custom mounts to add when attaching
 
 ---Configuration for mounts when using attach command
+---NOTE: when attaching in a separate command, it is useful to set
+---always to true, since these have to be attached when starting
 ---Useful to mount neovim configuration into container
 ---Applicable only to `devcontainer.commands` functions!
 ---@type AttachMountsOpts
 M.attach_mounts = {
+	always = false,
 	neovim_config = {
-		enabled = true,
+		enabled = false,
 		options = { "readonly" },
 	},
 	neovim_data = {
-		enabled = true,
+		enabled = false,
 		options = {},
 	},
 	neovim_state = {
-		enabled = true,
+		enabled = false,
 		options = {},
 	},
 	custom_mounts = {},

--- a/lua/devcontainer/init.lua
+++ b/lua/devcontainer/init.lua
@@ -67,6 +67,7 @@ function M.setup(opts)
 	if opts.attach_mounts then
 		local am = opts.attach_mounts
 		v.validate_deep(am, "opts.attach_mounts", {
+			always = "boolean",
 			neovim_config = "table",
 			neovim_data = "table",
 			neovim_state = "table",
@@ -165,6 +166,18 @@ function M.setup(opts)
 		end, {
 			nargs = 0,
 			desc = "Start either compose, dockerfile or image from .devcontainer.json",
+		})
+		vim.api.nvim_create_user_command("DevcontainerStartAutoAndAttach", function(_)
+			commands.start_auto(nil, true)
+		end, {
+			nargs = 0,
+			desc = "Start and attach to either compose, dockerfile or image from .devcontainer.json",
+		})
+		vim.api.nvim_create_user_command("DevcontainerAttachAuto", function(_)
+			commands.attach_auto()
+		end, {
+			nargs = 0,
+			desc = "Attach to either compose, dockerfile or image from .devcontainer.json",
 		})
 		vim.api.nvim_create_user_command("DevcontainerStopAuto", function(_)
 			commands.stop_auto()

--- a/scripts/docs-template.txt
+++ b/scripts/docs-template.txt
@@ -107,22 +107,26 @@ It is possible to override some of the functionality of the plugin with options 
     -- This can be useful to mount local configuration
     -- And any other mounts when attaching to containers with this plugin
     attach_mounts = {
+      -- Can be set to true to always mount items defined below
+      -- And not only when directly attaching
+      -- This can be useful if executing attach command separately
+      always = false,
       neovim_config = {
         -- enables mounting local config to /root/.config/nvim in container
-        enabled = true,
+        enabled = false,
         -- makes mount readonly in container
         options = { "readonly" }
       },
       neovim_data = {
         -- enables mounting local data to /root/.local/share/nvim in container
-        enabled = true,
+        enabled = false,
         -- no options by default
         options = {}
       },
       -- Only useful if using neovim 0.8.0+
       neovim_state = {
         -- enables mounting local state to /root/.local/state/nvim in container
-        enabled = true,
+        enabled = false,
         -- no options by default
         options = {}
       },
@@ -152,6 +156,8 @@ If not disabled by using {generate_commands = false} in setup, this plugin provi
 *:DevcontainerComposeDown* - run docker-compose down based on devcontainer.json
 *:DevcontainerComposeRm* - run docker-compose rm based on devcontainer.json
 *:DevcontainerStartAuto* - start whatever is defined in devcontainer.json
+*:DevcontainerStartAutoAndAttach* - start and attach to whatever is defined in devcontainer.json
+*:DevcontainerAttachAuto* - attach to whatever is defined in devcontainer.json
 *:DevcontainerStopAuto* - stop whatever was started based on devcontainer.json
 *:DevcontainerStopAll* - stop everything started with this plugin (in current session)
 *:DevcontainerRemoveAll* - remove everything started with this plugin (in current session)


### PR DESCRIPTION
This closes #60
This closes #59

BREAKING CHANGE: neovim configuration is no longer automatically mounted
It has to be enabled in setup
It is also only mounted if attaching directly
To better support separate attach command, set attach_mounts.always flag
to true in setup, to always mount configured neovim points