### PR TITLE
Address nvim v0.9 treesitter deprecation warning

### DIFF
--- a/lua/devcontainer/config_file/jsonc.lua
+++ b/lua/devcontainer/config_file/jsonc.lua
@@ -11,7 +11,7 @@ local function clean_jsonc(jsonc_content)
   local parser = vim.treesitter.get_string_parser(jsonc_content, "jsonc")
   local tree = parser:parse()
   local root = tree[1]:root()
-  local query = vim.treesitter.parse_query("jsonc", "((comment)+ @c)")
+  local query = vim.treesitter.query.parse("jsonc", "((comment)+ @c)")
   local lines = vim.split(jsonc_content, "\n")
 
   for _, node, _ in query:iter_captures(root) do


### PR DESCRIPTION
To address the following warning from nvim v0.9 when parsing the jsonc devcontainer file:

```
vim.treesitter.parse_query() is deprecated, use vim.treesitter.query.parse_query() instead. :help deprecated
This feature will be removed in Nvim version 0.10
```