### PR TITLE
fix: Fixes attempt to call field 'file_path' (a string value) in ImageRun

### DIFF
--- a/lua/devcontainer/commands.lua
+++ b/lua/devcontainer/commands.lua
@@ -382,7 +382,8 @@ function M.docker_image_run(callback)
         "Successfully started image ("
           .. config.image
           .. ") from "
-          .. config.metadata.file_path(" - container id: ")
+          .. config.metadata.file_path
+          .. " - container id: "
           .. container_id
       )
     end


### PR DESCRIPTION
Running :DevcontainerImageRun
```
Error executing vim.schedule lua callback: ...im/lazy/nvim-dev-container/lua/devcontainer/commands.lua:385: attempt to call field 'file_path' (a string value) stack traceback:
        ...im/lazy/nvim-dev-container/lua/devcontainer/commands.lua:385: in function 'on_success'
        ...im/lazy/nvim-dev-container/lua/devcontainer/commands.lua:401: in function 'on_success'
        ...nvim/lazy/nvim-dev-container/lua/devcontainer/docker.lua:316: in function 'onexit'
        ...vim-dev-container/lua/devcontainer/internal/executor.lua:88: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

This looks like a syntax error at first glance - though this fix is untested.