### PR TITLE
Update README: Branch main requires neovim v0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Goal of this plugin is to provide functionality similar to VSCode's [remote cont
 
 ## Requirements
 
-- [NeoVim](https://neovim.io) version 0.7.0+ (previous versions may be supported, but are not tested - commands and autocommands will definitely fail)
+- [NeoVim](https://neovim.io) version 0.9.0+ (previous versions may be supported, but are not tested - commands and autocommands will definitely fail)
 - [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter) with included `jsonc` parser (or manually installed jsonc parser)
 
 ## Installation


### PR DESCRIPTION
Branch `main` does not work with older versions or neovim anymore because of changes made for v0.9 ( https://github.com/esensar/nvim-dev-container/commit/00bce050f109266797d6bfb96258390be9b455ba )

Example of error you get if you try to run it with neovim v0.8.3:
```
Parsing devcontainer config failed: ".../jsonc.lua:14: attempt to call field 'parse' (a nil value)"
```